### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Spell Check
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/FredM67/PVRouter-3-phase/security/code-scanning/4](https://github.com/FredM67/PVRouter-3-phase/security/code-scanning/4)

To fix this issue, we should explicitly limit the permissions granted to the GITHUB_TOKEN in this workflow. The best approach is to add a top-level `permissions` block granting only read access (`contents: read`). This ensures all jobs in the workflow run with the minimum permissions required. Place the `permissions:` block after the workflow `name` and before the `on:` block (recommended in documentation). No other code changes are required, as neither the checkout action nor codespell require write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
