### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -11,6 +11,8 @@ on:
   
 jobs:
   deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: DenverCoder1/doxygen-github-pages-action@v2.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/FredM67/PVRouter-3-phase/security/code-scanning/3](https://github.com/FredM67/PVRouter-3-phase/security/code-scanning/3)

To fix this issue, add an explicit `permissions` block specifying only the required access for the job. For documentation publishing via the Doxygen GitHub Pages Action, the workflow job likely needs write access to the repository `contents` for pushing documentation updates. The best placement is beneath the `jobs: deploy:` section, above `runs-on: ubuntu-latest`, unless multiple jobs are present and a workflow-wide permissions block is desired.  
Specifically, insert:

```yaml
permissions:
  contents: write
```
above `runs-on: ubuntu-latest`.  
No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
